### PR TITLE
Specify AirSim settings.json file path

### DIFF
--- a/Source/AirLib/include/common/common_utils/FileSystem.hpp
+++ b/Source/AirLib/include/common/common_utils/FileSystem.hpp
@@ -48,6 +48,19 @@ public:
     #endif
     }
 
+    static std::string getSettingsFolder(std::string fileName)
+    {
+        //Windows
+#ifdef _WIN32
+        std::wstring userProfile = _wgetenv(L"SIMBOTIC_AIRSIM_SETTINGS");
+        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+        return converter.to_bytes(userProfile);
+        // Linux
+#else
+        return combine(std::getenv("SIMBOTIC_AIRSIM_SETTINGS"), fileName);
+#endif
+    }
+
     static std::string getUserDocumentsFolder();
 
 	static std::string getExecutableFolder();

--- a/Source/SimHUD/SimHUD.cpp
+++ b/Source/SimHUD/SimHUD.cpp
@@ -8,6 +8,7 @@
 #include "Vehicles/ComputerVision/SimModeComputerVision.h"
 
 #include "common/AirSimSettings.hpp"
+#include "common/common_utils/FileSystem.hpp"
 #include <stdexcept>
 
 
@@ -345,6 +346,7 @@ void ASimHUD::initializeSubWindows()
 // Attempts to parse the settings text from one of multiple locations.
 // First, check the command line for settings provided via "-s" or "--settings" arguments
 // Next, check the executable's working directory for the settings file.
+// Next, check SIMBOTIC_AIRSIM_SETTINGS environment variable.
 // Finally, check the user's documents folder. 
 // If the settings file cannot be read, throw an exception
 
@@ -353,6 +355,8 @@ bool ASimHUD::getSettingsText(std::string& settingsText)
     return (getSettingsTextFromCommandLine(settingsText)
         ||
         readSettingsTextFromFile(FString(msr::airlib::Settings::getExecutableFullPath("settings.json").c_str()), settingsText)
+        ||
+        readSettingsTextFromFile(FString(common_utils::FileSystem::getSettingsFolder("settings.json").c_str()), settingsText)
         ||
         readSettingsTextFromFile(FString(msr::airlib::Settings::Settings::getUserDirectoryFullPath("settings.json").c_str()), settingsText));
 }

--- a/Source/SimHUD/SimHUD.cpp
+++ b/Source/SimHUD/SimHUD.cpp
@@ -345,6 +345,7 @@ void ASimHUD::initializeSubWindows()
 
 // Attempts to parse the settings text from one of multiple locations.
 // First, check the command line for settings provided via "-s" or "--settings" arguments
+// Next, check the command line for settings file path provided via "--airsim" argument.
 // Next, check the executable's working directory for the settings file.
 // Next, check SIMBOTIC_AIRSIM_SETTINGS environment variable.
 // Finally, check the user's documents folder. 
@@ -353,6 +354,8 @@ void ASimHUD::initializeSubWindows()
 bool ASimHUD::getSettingsText(std::string& settingsText) 
 {
     return (getSettingsTextFromCommandLine(settingsText)
+        ||
+        readSettingsTextFromFile(FString(getSettingsFilePathFromCommandLine("settings.json").c_str()), settingsText)
         ||
         readSettingsTextFromFile(FString(msr::airlib::Settings::getExecutableFullPath("settings.json").c_str()), settingsText)
         ||
@@ -383,6 +386,21 @@ bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText)
     }
 
     return found;
+}
+
+std::string ASimHUD::getSettingsFilePathFromCommandLine(std::string fileName)
+{
+    std::string path;
+    FString settingsTextFStringParsed;
+    const TCHAR* commandLineArgs = FCommandLine::Get();
+    
+    if (FParse::Param(commandLineArgs, TEXT("-airsim"))) {
+        FString commandLineArgsFString = FString(commandLineArgs);
+        int idx = commandLineArgsFString.Find(TEXT("-airsim"));
+        FString settingFilePath = commandLineArgsFString.RightChop(idx + 8);
+        path = common_utils::FileSystem::combine(std::string(TCHAR_TO_UTF8(*settingFilePath)), fileName);
+    }
+    return path;
 }
 
 bool ASimHUD::readSettingsTextFromFile(FString settingsFilepath, std::string& settingsText) 

--- a/Source/SimHUD/SimHUD.h
+++ b/Source/SimHUD/SimHUD.h
@@ -66,6 +66,7 @@ private:
 
     bool getSettingsText(std::string& settingsText);
     bool getSettingsTextFromCommandLine(std::string& settingsText);
+    std::string getSettingsFilePathFromCommandLine(std::string fileName);
     bool readSettingsTextFromFile(FString fileName, std::string& settingsText);
     std::string getSimModeFromUser();
 


### PR DESCRIPTION
Specify AirSim **settings.json** file path by using:

1.  **SIMBOTIC_AIRSIM_SETTINGS** environment variable.
2.  **airsim** command line argument. Example: `./run.sh /home/user/some_path`